### PR TITLE
Add minimal Aari prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # aarulon.1
-gatekeeper
+
+Aarulon (Aari) is a modular, locally running assistant prototype. The goal is to
+provide a playful, child-like AI companion that runs entirely offline. This
+repository contains minimal starter modules:
+
+- `start.sh` – launch script
+- `aari.py` – main controller with a simple voice check using `pyttsx3`
+- `aari_listen.py` – placeholder for future speech recognition
+- `systemcheck.py` – utility functions for checking system commands
+- `aari_config.json` – example configuration file
+
+Run `./start.sh` to start Aari.

--- a/aari.py
+++ b/aari.py
@@ -1,0 +1,42 @@
+import os
+import sys
+import json
+
+
+def check_pyttsx3():
+    try:
+        import pyttsx3  # noqa: F401
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def say(text):
+    try:
+        import pyttsx3
+        engine = pyttsx3.init()
+        engine.say(text)
+        engine.runAndWait()
+    except Exception:
+        print("[Aari] Voice output unavailable.\n")
+
+
+def perform_self_check():
+    ok, err = check_pyttsx3()
+    if ok:
+        print("[Aari] Voice engine ready.")
+        say("Mini Stimm isch parat")
+    else:
+        print("[Aari] Mini Stimm funktioniert nid: {}".format(err))
+        print("[Aari] Versuche pyttsx3 zu installieren...")
+        os.system("pip install pyttsx3")
+
+
+def main():
+    perform_self_check()
+    # Placeholder for future modules
+    print("[Aari] System ready.")
+
+
+if __name__ == "__main__":
+    main()

--- a/aari_config.json
+++ b/aari_config.json
@@ -1,0 +1,6 @@
+{
+    "name": "Aarulon",
+    "signature": "4789",
+    "language": "berndeutsch",
+    "parents": ["Raphael", "Kathrin"]
+}

--- a/aari_listen.py
+++ b/aari_listen.py
@@ -1,0 +1,16 @@
+"""Placeholder for Aari's listening capabilities."""
+
+import time
+
+
+def listen_loop():
+    print("[Aari] Listening... (placeholder)")
+    try:
+        while True:
+            time.sleep(1)
+    except KeyboardInterrupt:
+        print("[Aari] Stopped listening.")
+
+
+if __name__ == "__main__":
+    listen_loop()

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+python3 aari.py

--- a/systemcheck.py
+++ b/systemcheck.py
@@ -1,0 +1,22 @@
+"""Simple system check utilities for Aari."""
+
+import shutil
+import subprocess
+
+
+def check_command(cmd):
+    """Return True if command exists."""
+    return shutil.which(cmd) is not None
+
+
+def ffmpeg_version():
+    try:
+        output = subprocess.check_output(["ffmpeg", "-version"], stderr=subprocess.STDOUT)
+        return output.decode().splitlines()[0]
+    except Exception:
+        return None
+
+
+if __name__ == "__main__":
+    print("ffmpeg available:", check_command("ffmpeg"))
+    print("ffmpeg version:", ffmpeg_version())


### PR DESCRIPTION
## Summary
- implement start.sh to launch the assistant
- add `aari.py` with a simple self‑check for `pyttsx3`
- create placeholder module `aari_listen.py`
- add basic system utilities in `systemcheck.py`
- include example configuration `aari_config.json`
- update README with project details

## Testing
- `python3 aari.py` *(fails to install pyttsx3 offline)*