### PR TITLE
Grundversion auf Deutsch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,16 @@
 # aarulon.1
 
-Aarulon (Aari) is a modular, locally running assistant prototype. The goal is to
-provide a playful, child-like AI companion that runs entirely offline. This
-repository contains minimal starter modules:
+Aarulon (Aari) ist ein modular aufgebauter Assistent, der komplett lokal
+ausgeführt wird. Ziel ist ein verspielter, kindlicher Begleiter, der ohne
+Internetverbindung läuft. Diese Basisversion verwendet Deutsch als
+Grundsprache. Weitere Sprachen können später daraus abgeleitet werden.
 
-- `start.sh` – launch script
-- `aari.py` – main controller with a simple voice check using `pyttsx3`
-- `aari_listen.py` – placeholder for future speech recognition
-- `systemcheck.py` – utility functions for checking system commands
-- `aari_config.json` – example configuration file
+Enthalten sind folgende Minimalmodule:
 
-Run `./start.sh` to start Aari.
+- `start.sh` – Startskript
+- `aari.py` – Hauptcontroller mit einfachem Sprachtest über `pyttsx3`
+- `aari_listen.py` – Platzhalter für zukünftige Spracherkennung
+- `systemcheck.py` – Hilfsfunktionen für Systemkommandos
+- `aari_config.json` – Beispielkonfiguration
+
+Starte Aari mit `./start.sh`.

--- a/aari.py
+++ b/aari.py
@@ -1,6 +1,7 @@
 import os
-import sys
 import json
+
+from messages import get_message, BASE_LANG
 
 
 def check_pyttsx3():
@@ -11,31 +12,41 @@ def check_pyttsx3():
         return False, str(e)
 
 
-def say(text):
+def say(text, lang):
     try:
         import pyttsx3
         engine = pyttsx3.init()
         engine.say(text)
         engine.runAndWait()
     except Exception:
-        print("[Aari] Voice output unavailable.\n")
+        print(get_message("voice_output_unavailable", lang))
 
 
-def perform_self_check():
+def perform_self_check(lang):
     ok, err = check_pyttsx3()
     if ok:
-        print("[Aari] Voice engine ready.")
-        say("Mini Stimm isch parat")
+        print(get_message("voice_engine_ready", lang))
+        say(get_message("say_voice_ready", lang), lang)
     else:
-        print("[Aari] Mini Stimm funktioniert nid: {}".format(err))
-        print("[Aari] Versuche pyttsx3 zu installieren...")
+        print(get_message("voice_failure", lang).format(err=err))
+        print(get_message("installing_pyttsx3", lang))
         os.system("pip install pyttsx3")
 
 
+def load_config():
+    try:
+        with open("aari_config.json", "r") as f:
+            return json.load(f)
+    except Exception:
+        return {}
+
+
 def main():
-    perform_self_check()
+    config = load_config()
+    lang = config.get("language", BASE_LANG)
+    perform_self_check(lang)
     # Placeholder for future modules
-    print("[Aari] System ready.")
+    print(get_message("system_ready", lang))
 
 
 if __name__ == "__main__":

--- a/aari_config.json
+++ b/aari_config.json
@@ -1,6 +1,6 @@
 {
     "name": "Aarulon",
     "signature": "4789",
-    "language": "berndeutsch",
+    "language": "de",
     "parents": ["Raphael", "Kathrin"]
 }

--- a/aari_listen.py
+++ b/aari_listen.py
@@ -4,12 +4,12 @@ import time
 
 
 def listen_loop():
-    print("[Aari] Listening... (placeholder)")
+    print("[Aari] Lausche... (Platzhalter)")
     try:
         while True:
             time.sleep(1)
     except KeyboardInterrupt:
-        print("[Aari] Stopped listening.")
+        print("[Aari] Lauschen beendet.")
 
 
 if __name__ == "__main__":

--- a/messages.py
+++ b/messages.py
@@ -1,0 +1,35 @@
+MESSAGES = {
+    "de": {
+        "voice_engine_ready": "[Aari] Sprachengine bereit.",
+        "say_voice_ready": "Meine Stimme ist bereit",
+        "voice_failure": "[Aari] Meine Stimme funktioniert nicht: {err}",
+        "installing_pyttsx3": "[Aari] Versuche pyttsx3 zu installieren...",
+        "voice_output_unavailable": "[Aari] Sprachausgabe nicht verf\u00fcgbar.",
+        "system_ready": "[Aari] System bereit."
+    },
+    "berndeutsch": {
+        "voice_engine_ready": "[Aari] Stimm-Engine parat.",
+        "say_voice_ready": "Mini Stimm isch parat",
+        "voice_failure": "[Aari] Mini Stimm funktioniert nid: {err}",
+        "installing_pyttsx3": "[Aari] Versuche pyttsx3 z'installiere...",
+        "voice_output_unavailable": "[Aari] Sprachausgab n\u00f6d verf\u00fcgbar.",
+        "system_ready": "[Aari] System parat."
+    },
+    "en": {
+        "voice_engine_ready": "[Aari] Voice engine ready.",
+        "say_voice_ready": "My voice is ready",
+        "voice_failure": "[Aari] My voice doesn't work: {err}",
+        "installing_pyttsx3": "[Aari] Trying to install pyttsx3...",
+        "voice_output_unavailable": "[Aari] Voice output unavailable.",
+        "system_ready": "[Aari] System ready."
+    }
+}
+
+BASE_LANG = "de"
+
+
+def get_message(key, lang=None):
+    lang = lang or BASE_LANG
+    if lang in MESSAGES and key in MESSAGES[lang]:
+        return MESSAGES[lang][key]
+    return MESSAGES[BASE_LANG].get(key, "")

--- a/systemcheck.py
+++ b/systemcheck.py
@@ -1,4 +1,4 @@
-"""Simple system check utilities for Aari."""
+"""Einfache Systemprüfungen für Aari."""
 
 import shutil
 import subprocess
@@ -18,5 +18,5 @@ def ffmpeg_version():
 
 
 if __name__ == "__main__":
-    print("ffmpeg available:", check_command("ffmpeg"))
-    print("ffmpeg version:", ffmpeg_version())
+    print("ffmpeg verfügbar:", check_command("ffmpeg"))
+    print("ffmpeg Version:", ffmpeg_version())


### PR DESCRIPTION
## Summary
- translate README and scripts to German
- set `language` default to `de`
- add `messages.py` to store translatable strings
- use translation module in `aari.py`

## Testing
- `python3 -m py_compile aari.py aari_listen.py systemcheck.py messages.py`