### PR TITLE
Add system checks and show info

### DIFF
--- a/aari.py
+++ b/aari.py
@@ -2,14 +2,7 @@ import os
 import json
 
 from messages import get_message, BASE_LANG
-
-
-def check_pyttsx3():
-    try:
-        import pyttsx3  # noqa: F401
-        return True, None
-    except Exception as e:
-        return False, str(e)
+from systemcheck import check_pyttsx3, get_system_data
 
 
 def say(text, lang):
@@ -33,6 +26,13 @@ def perform_self_check(lang):
         os.system("pip install pyttsx3")
 
 
+def display_system_data():
+    data = get_system_data()
+    print("[Aari] Systemdaten:")
+    for key, value in data.items():
+        print(f"  {key}: {value}")
+
+
 def load_config():
     try:
         with open("aari_config.json", "r") as f:
@@ -44,6 +44,7 @@ def load_config():
 def main():
     config = load_config()
     lang = config.get("language", BASE_LANG)
+    display_system_data()
     perform_self_check(lang)
     # Placeholder for future modules
     print(get_message("system_ready", lang))

--- a/systemcheck.py
+++ b/systemcheck.py
@@ -2,6 +2,7 @@
 
 import shutil
 import subprocess
+import platform
 
 
 def check_command(cmd):
@@ -17,6 +18,64 @@ def ffmpeg_version():
         return None
 
 
+def check_pyttsx3():
+    """Check if pyttsx3 can be imported."""
+    try:
+        import pyttsx3  # noqa: F401
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def check_audio_output():
+    """Check if an audio output device is available via pyaudio."""
+    try:
+        import pyaudio
+        pa = pyaudio.PyAudio()
+        pa.get_default_output_device_info()
+        pa.terminate()
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def check_audio_input():
+    """Check if an audio input device is available via pyaudio."""
+    try:
+        import pyaudio
+        pa = pyaudio.PyAudio()
+        pa.get_default_input_device_info()
+        pa.terminate()
+        return True, None
+    except Exception as e:
+        return False, str(e)
+
+
+def get_system_data():
+    """Collect basic system data used by Aari."""
+    data = {
+        "platform": platform.platform(),
+        "python_version": platform.python_version(),
+        "ffmpeg_available": check_command("ffmpeg"),
+        "ffmpeg_version": ffmpeg_version(),
+    }
+
+    ok, err = check_pyttsx3()
+    data["pyttsx3_available"] = ok
+    data["pyttsx3_error"] = err
+
+    ok, err = check_audio_output()
+    data["audio_output_available"] = ok
+    data["audio_output_error"] = err
+
+    ok, err = check_audio_input()
+    data["audio_input_available"] = ok
+    data["audio_input_error"] = err
+
+    return data
+
+
 if __name__ == "__main__":
-    print("ffmpeg verfügbar:", check_command("ffmpeg"))
-    print("ffmpeg Version:", ffmpeg_version())
+    data = get_system_data()
+    for key, value in data.items():
+        print(f"{key}: {value}")


### PR DESCRIPTION
## Summary
- check pyttsx3, audio output and input with pyaudio
- expose collected system data
- print system data when starting aari

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 aari.py` *(fails to install pyttsx3 due to no network)*