### PR TITLE
Add robot fish control module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ Enthalten sind folgende Minimalmodule:
 - `systemcheck.py` – Hilfsfunktionen für Systemkommandos
 - `aari_config.json` – Beispielkonfiguration
 - `install_aari.py` – Einfache plattformübergreifende Installation
+- `robotfish.py` – Steuerbefehle für den Roboterfisch
 
 Starte Aari klassisch mit `./start.sh` oder nutze `install_aari.py` für
+- `robotfish.py` – Steuerbefehle für den Roboterfisch
 eine automatische Installation der benötigten Python-Pakete.
 
 ## Abhängigkeiten
@@ -29,6 +31,7 @@ herunterzuladen und Aari zu starten:
 
 ```bash
 python3 install_aari.py
+- `robotfish.py` – Steuerbefehle für den Roboterfisch
 ```
 
 Das Skript prüft, ob das Paket `pyttsx3` vorhanden ist und installiert es
@@ -49,6 +52,8 @@ Oder direkt via Python:
 ```bash
 python3 aari.py
 ```
+## Roboterfisch-Steuerung
+Mit dem Modul `robotfish.py` kann Aari einen Roboterfisch kontrollieren. Die Funktion `control_robot_fish()` akzeptiert nur die Signatur `4789` und gibt den ausgefuehrten Befehl im Dry-Run-Modus aus.
 
 ## Konfiguration
 

--- a/robotfish.py
+++ b/robotfish.py
@@ -1,0 +1,43 @@
+"""Control utilities for the robot fish."""
+
+import subprocess
+
+ALLOWED_SIGNATURE = "4789"
+
+
+def control_robot_fish(action: str, signature: str, dry_run: bool = True) -> bool:
+    """Send a command to the robot fish.
+
+    Parameters
+    ----------
+    action:
+        The command to send, e.g. "left", "right", "forward", "stop".
+    signature:
+        Signature identifying the user. Only signature '4789' is allowed.
+    dry_run:
+        If ``True``, the command is printed instead of executed.
+
+    Returns
+    -------
+    bool
+        ``True`` on success, ``False`` otherwise.
+
+    Raises
+    ------
+    PermissionError
+        If the provided signature is not authorized.
+    """
+    if str(signature) != ALLOWED_SIGNATURE:
+        raise PermissionError("Unauthorized signature")
+
+    command = f"robotfish --action {action}"
+
+    if dry_run:
+        print(f"[Aari] {command}")
+        return True
+    try:
+        subprocess.check_call(command.split())
+        return True
+    except Exception as exc:  # pragma: no cover - system dependent
+        print(f"[Aari] Robot fish command failed: {exc}")
+        return False

--- a/tests/test_robotfish.py
+++ b/tests/test_robotfish.py
@@ -1,0 +1,13 @@
+import pytest
+import robotfish
+
+
+def test_control_robot_fish_allows_signature(capsys):
+    assert robotfish.control_robot_fish("swim", "4789") is True
+    out = capsys.readouterr().out
+    assert "robotfish --action swim" in out
+
+
+def test_control_robot_fish_denies_signature():
+    with pytest.raises(PermissionError):
+        robotfish.control_robot_fish("swim", "0000")


### PR DESCRIPTION
## Summary
- add `robotfish.py` with function `control_robot_fish()` for signature `4789`
- expose robot fish module in README
- document new robot fish section
- add tests for robotfish control

## Testing
- `python -m pytest -q`