### PR TITLE
Implement CLI and update installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ Enthalten sind folgende Minimalmodule:
 - `systemcheck.py` – Hilfsfunktionen für Systemkommandos
 - `aari_config.json` – Beispielkonfiguration
 - `install_aari.py` – Einfache plattformübergreifende Installation
-- `robotfish.py` – Steuerbefehle für den Roboterfisch
 
-Starte Aari klassisch mit `./start.sh` oder nutze `install_aari.py` für
-- `robotfish.py` – Steuerbefehle für den Roboterfisch
-eine automatische Installation der benötigten Python-Pakete.
+Starte Aari klassisch mit `./start.sh <befehl>` oder nutze `install_aari.py`
+für eine automatische Installation der benötigten Python-Pakete.
 
 ## Abhängigkeiten
+
+Alle benötigten Pakete sind in `requirements.txt` aufgelistet:
 
 * `pyttsx3` für die Sprachausgabe
 * `vosk` und `sounddevice` für die Offline-Spracherkennung
@@ -27,31 +27,31 @@ eine automatische Installation der benötigten Python-Pakete.
 ## Installation
 
 Führe zuerst das Installationsskript aus, um die Abhängigkeiten
-herunterzuladen und Aari zu starten:
+zu installieren und Aari zu starten:
 
 ```bash
 python3 install_aari.py
-- `robotfish.py` – Steuerbefehle für den Roboterfisch
 ```
 
-Das Skript prüft, ob das Paket `pyttsx3` vorhanden ist und installiert es
-bei Bedarf automatisch. Alternativ kann das Paket auch manuell mittels
-`pip install pyttsx3` installiert werden.
+Das Skript installiert automatisch alle Pakete aus `requirements.txt`.
 
 ## Start
 
-Nach erfolgreicher Installation lässt sich Aari mit dem beiliegenden
-Skript starten:
+Nach erfolgreicher Installation kann das Kommandozeilen-Werkzeug
+gestartet werden:
 
 ```bash
-./start.sh
+./start.sh <befehl>
 ```
 
 Oder direkt via Python:
 
 ```bash
-python3 aari.py
+python3 cli.py <befehl>
 ```
+
+Verfügbare Befehle sind `self-check`, `system-data`, `listen` und
+`say <text>`.
 ## Roboterfisch-Steuerung
 Mit dem Modul `robotfish.py` kann Aari einen Roboterfisch kontrollieren. Die Funktion `control_robot_fish()` akzeptiert nur die Signatur `4789` und gibt den ausgefuehrten Befehl im Dry-Run-Modus aus.
 

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,34 @@
+import argparse
+import aari
+import aari_listen
+from messages import BASE_LANG
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Aari command line interface")
+    sub = parser.add_subparsers(dest="command")
+
+    sub.add_parser("self-check", help="Run self check")
+    sub.add_parser("system-data", help="Show system data")
+    sub.add_parser("listen", help="Start voice recognition loop")
+    say_p = sub.add_parser("say", help="Speak the given text")
+    say_p.add_argument("text")
+
+    args = parser.parse_args(argv)
+
+    if args.command == "self-check":
+        lang = aari.load_config().get("language", BASE_LANG)
+        aari.perform_self_check(lang)
+    elif args.command == "system-data":
+        aari.display_system_data()
+    elif args.command == "listen":
+        aari_listen.listen_loop()
+    elif args.command == "say":
+        lang = aari.load_config().get("language", BASE_LANG)
+        aari.say(args.text, lang)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    main()

--- a/install_aari.py
+++ b/install_aari.py
@@ -3,34 +3,43 @@ import sys
 import subprocess
 import platform
 
+REQUIREMENTS_FILE = "requirements.txt"
 
-def install_pyttsx3():
-    """Install the pyttsx3 package using pip."""
+
+def install_requirements():
+    """Install required packages using pip."""
+    if os.path.isfile(REQUIREMENTS_FILE):
+        print("Installing dependencies...")
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "-r", REQUIREMENTS_FILE])
+            return True
+        except Exception as e:  # pragma: no cover - external dependency
+            print("Failed to install dependencies:", e)
+            return False
+    # fallback: install pyttsx3 only
     try:
         import pyttsx3  # noqa: F401
         return True
     except Exception:
-        pass
-
-    print("Installing pyttsx3...")
-    try:
-        subprocess.check_call([sys.executable, "-m", "pip", "install", "pyttsx3"])
-        return True
-    except Exception as e:
-        print("Failed to install pyttsx3:", e)
-        return False
+        print("Installing pyttsx3...")
+        try:
+            subprocess.check_call([sys.executable, "-m", "pip", "install", "pyttsx3"])
+            return True
+        except Exception as e:  # pragma: no cover - external dependency
+            print("Failed to install pyttsx3:", e)
+            return False
 
 
 def main():
     print("=== Aari Installer ===")
     print(f"Detected platform: {platform.system()}")
 
-    if not install_pyttsx3():
-        print("Please install pyttsx3 manually and rerun this script.")
+    if not install_requirements():
+        print("Please install the requirements manually and rerun this script.")
         input("Press Enter to exit...")
         return
 
-    print("pyttsx3 installed.")
+    print("Dependencies installed.")
     print("Starting Aari...")
 
     # Start the main Aari script

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pyttsx3
+vosk
+sounddevice

--- a/start.sh
+++ b/start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-python3 aari.py
+python3 cli.py "$@"

--- a/tests/test_aari.py
+++ b/tests/test_aari.py
@@ -2,6 +2,9 @@ import sys
 import builtins
 import os
 import types
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 import pytest
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,45 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import aari
+import aari_listen
+from cli import main
+
+
+def test_cli_self_check(monkeypatch):
+    called = []
+    monkeypatch.setattr(aari, "load_config", lambda: {"language": "en"})
+    monkeypatch.setattr(aari, "perform_self_check", lambda lang: called.append(lang))
+    main(["self-check"])
+    assert called == ["en"]
+
+
+def test_cli_system_data(monkeypatch):
+    called = []
+    monkeypatch.setattr(aari, "display_system_data", lambda: called.append(True))
+    main(["system-data"])
+    assert called == [True]
+
+
+def test_cli_listen(monkeypatch):
+    called = []
+    monkeypatch.setattr(aari_listen, "listen_loop", lambda: called.append(True))
+    main(["listen"])
+    assert called == [True]
+
+
+def test_cli_say(monkeypatch):
+    called = []
+    monkeypatch.setattr(aari, "load_config", lambda: {"language": "en"})
+    monkeypatch.setattr(aari, "say", lambda text, lang: called.append((text, lang)))
+    main(["say", "hi"])
+    assert called == [("hi", "en")]
+
+
+def test_cli_no_args(capsys):
+    main([])
+    out = capsys.readouterr().out
+    assert "usage:" in out
+

--- a/tests/test_messages.py
+++ b/tests/test_messages.py
@@ -1,4 +1,8 @@
 import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from messages import get_message
 

--- a/tests/test_robotfish.py
+++ b/tests/test_robotfish.py
@@ -1,4 +1,9 @@
 import pytest
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
 import robotfish
 
 


### PR DESCRIPTION
## Summary
- add `cli.py` with basic subcommands
- update start script to invoke CLI
- install dependencies via `requirements.txt`
- document CLI usage in README
- add new tests for CLI and update existing tests for import path

## Testing
- `pytest -q`