### PR TITLE
Add autostart and HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,17 @@ Sprachblöcke ergänzt werden. Nach dem Hinzufügen einer neuen Sprache
 muss der entsprechende Sprachcode in der Konfiguration unter
 `language` eingetragen werden, um Aari mit dieser Lokalisierung zu
 starten.
+
+## Autostart-Service
+
+Mit `setup_autostart.py` kann ein systemd-Dienst angelegt werden, der Aari beim Benutzer-Login automatisch startet. Das Skript erzeugt die Datei `~/.config/systemd/user/aari.service`.
+
+```bash
+python3 setup_autostart.py
+systemctl --user enable aari.service
+systemctl --user start aari.service
+```
+
+## Einfacher HTTP-Server
+
+`aari_server.py` stellt einen kleinen HTTP-Server auf Port 4789 bereit. Mit `GET /say?text=<TEXT>&signature=4789` spricht Aari den Text. Ein `GET /ping` liefert `pong`. Bei falscher Signatur antwortet der Server mit `403`.

--- a/README_en.md
+++ b/README_en.md
@@ -74,3 +74,17 @@ Adjusting this file lets you easily rename Aari or switch to another language.
 ## Localization
 
 All message texts are stored in `messages.py`. You can add more languages there. After adding a language, set its code in the configuration under `language` to start Aari with that localization.
+
+## Autostart service
+
+`setup_autostart.py` creates a systemd unit so Aari starts automatically when the user logs in. It writes `~/.config/systemd/user/aari.service`.
+
+```bash
+python3 setup_autostart.py
+systemctl --user enable aari.service
+systemctl --user start aari.service
+```
+
+## Simple HTTP server
+
+`aari_server.py` provides a small HTTP server on port 4789. `GET /say?text=<TEXT>&signature=4789` will let Aari speak the text. A `GET /ping` returns `pong`. Requests with an invalid signature receive `403`.

--- a/aari_server.py
+++ b/aari_server.py
@@ -1,0 +1,59 @@
+import http.server
+import socketserver
+from urllib.parse import urlparse, parse_qs
+import threading
+
+import aari
+
+
+DEFAULT_PORT = 4789
+ALLOWED_SIGNATURE = str(aari.load_config().get("signature", ""))
+
+
+class AariRequestHandler(http.server.BaseHTTPRequestHandler):
+    """Simple HTTP request handler for Aari commands."""
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/ping":
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"pong")
+            return
+
+        if parsed.path == "/say":
+            params = parse_qs(parsed.query)
+            text = params.get("text", [""])[0]
+            signature = params.get("signature", [""])[0]
+            if signature != ALLOWED_SIGNATURE:
+                self.send_response(403)
+                self.end_headers()
+                self.wfile.write(b"Forbidden")
+                return
+            lang = aari.load_config().get("language")
+            try:
+                aari.say(text, lang)
+            except Exception:
+                # ignore voice output errors for server usage
+                pass
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"OK")
+            return
+
+        self.send_response(404)
+        self.end_headers()
+
+
+def run_server(host="0.0.0.0", port=DEFAULT_PORT):
+    """Start the HTTP server."""
+    with socketserver.TCPServer((host, port), AariRequestHandler) as httpd:
+        print(f"[Aari] Server running on {host}:{port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:  # pragma: no cover - manual stop
+            pass
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    run_server()

--- a/setup_autostart.py
+++ b/setup_autostart.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+
+SERVICE_NAME = "aari.service"
+
+
+SERVICE_TEMPLATE = """[Unit]
+Description=Aari Host Service
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={python} {script} listen
+WorkingDirectory={workdir}
+Restart=on-failure
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def generate_service_text(python_path: str = None, script_path: str = None) -> str:
+    """Return the systemd service file content."""
+    python_path = python_path or os.path.realpath(os.sys.executable)
+    script_path = script_path or os.path.join(Path(__file__).resolve().parent, "cli.py")
+    workdir = Path(script_path).resolve().parent
+    return SERVICE_TEMPLATE.format(python=python_path, script=script_path, workdir=workdir)
+
+
+def install_service(user_dir: Path = None) -> Path:
+    """Install the service file for the current user."""
+    user_dir = user_dir or Path.home() / ".config" / "systemd" / "user"
+    user_dir.mkdir(parents=True, exist_ok=True)
+    service_path = user_dir / SERVICE_NAME
+    service_path.write_text(generate_service_text())
+    return service_path
+
+
+if __name__ == "__main__":  # pragma: no cover - manual use
+    path = install_service()
+    print(f"Service installed at {path}")
+    print("Enable it with: systemctl --user enable aari.service && systemctl --user start aari.service")

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,20 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import setup_autostart
+
+
+def test_generate_service_text():
+    text = setup_autostart.generate_service_text("/usr/bin/python3", "/tmp/cli.py")
+    assert "ExecStart=/usr/bin/python3 /tmp/cli.py listen" in text
+
+
+def test_install_service(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    path = setup_autostart.install_service()
+    assert path.exists()
+    content = path.read_text()
+    assert "Aari Host Service" in content

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+import threading
+import socket
+import urllib.request
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import aari_server
+
+
+def run_temp_server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    thread = threading.Thread(target=aari_server.run_server, kwargs={"host": "127.0.0.1", "port": port}, daemon=True)
+    thread.start()
+    # wait for server to listen
+    for _ in range(10):
+        try:
+            with socket.create_connection(("127.0.0.1", port), timeout=0.1):
+                break
+        except OSError:
+            pass
+    return port
+
+
+def test_server_ping():
+    port = run_temp_server()
+    with urllib.request.urlopen(f"http://127.0.0.1:{port}/ping") as resp:
+        assert resp.read() == b"pong"
+
+
+def test_server_say_invalid_signature():
+    port = run_temp_server()
+    try:
+        urllib.request.urlopen(f"http://127.0.0.1:{port}/say?text=hi&signature=bad")
+    except Exception as e:
+        assert "403" in str(e)


### PR DESCRIPTION
## Summary
- add `setup_autostart.py` script to create systemd user service
- add `aari_server.py` simple HTTP server on port 4789
- document new features in README and README_en
- test autostart script and HTTP server

## Testing
- `pytest -q`